### PR TITLE
[#3] Implements basic specs for plant model controller

### DIFF
--- a/spec/requests/plants_spec.rb
+++ b/spec/requests/plants_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe "plants requests", type: :request do
+	shared_examples "a valid schema" do
+		context "a list of plants" do
+			it "should be a top-level array with two elements" do
+				expect(data).to be_a(Array)
+				expect(data.count).to eq(2)
+			end
+
+			it "should have timestamps" do
+				data.each do |datum|
+					expect(datum[:created_at].to_datetime).to_not be_nil
+					expect(datum[:updated_at].to_datetime).to_not be_nil
+				end
+			end
+		end
+	end
+
+  describe "GET /index" do
+		before do
+			get plants_url
+		end
+
+		let(:data) { JSON.parse(response.body, symbolize_names: true) }
+
+		it 'retrieves a list of plants' do
+			expect(response).to have_http_status(200)
+
+			first_plant = data.first
+			expect(first_plant[:id]).to be_a(Integer)
+			expect(first_plant[:name]).to eq("Stefan's Plant")
+			expect(first_plant[:species]).to eq('Peace Lily')
+
+			second_plant = data.last
+			expect(second_plant[:id]).to be_a(Integer)
+			expect(second_plant[:name]).to eq('Other Plant')
+			expect(second_plant[:species]).to eq('Parlor Palm')
+		end
+
+		it_behaves_like "a valid schema"
+  end
+end
+

--- a/spec/requests/plants_spec.rb
+++ b/spec/requests/plants_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'plants requests', type: :request do
+RSpec.describe 'plants requests - happy paths', type: :request do
 	shared_examples 'a valid schema' do
 		it 'should be a hash with five elements' do
 			expect(datum).to be_a(Hash)
@@ -20,7 +20,7 @@ RSpec.describe 'plants requests', type: :request do
 	end
 
 	# NOTE: These test cases rely upon fixtures for pre-defined model instances
-	describe 'GET /index' do
+	describe 'GET#index' do
 		before do
 			get plants_url
 		end
@@ -52,7 +52,7 @@ RSpec.describe 'plants requests', type: :request do
 		end
 	end
 
-	describe 'GET /:id' do
+	describe 'GET#show' do
 		before do
 			plant = Plant.create!(name: 'Spec plant', species: 'Spec species')
 			get plant_url(plant)
@@ -67,6 +67,80 @@ RSpec.describe 'plants requests', type: :request do
 
 			expect(datum[:name]).to eq('Spec plant')
 			expect(datum[:species]).to eq('Spec species')
+		end
+	end
+
+	describe 'POST#create' do
+		before do
+			post plants_url, params: {
+				plant: {
+					name: 'New plant',
+					species: 'Dracaena'
+				}
+			}
+		end
+
+		let(:datum) { JSON.parse(response.body, symbolize_names: true) }
+
+		it 'creates a `Plant` in the database' do
+			expect(plant = Plant.find_by(name: 'New plant')).to_not be_nil
+
+			expect(plant.name).to eq('New plant')
+			expect(plant.species).to eq('Dracaena')
+		end
+
+		it 'returns the plant' do
+			expect(response).to have_http_status(201)
+
+			expect(datum[:name]).to eq('New plant')
+			expect(datum[:species]).to eq('Dracaena')
+		end
+
+		it_behaves_like 'a valid schema'
+	end
+
+	describe 'PUT#update' do
+		before do
+			plant = Plant.first!
+			put plant_url(plant), params: {
+				plant: {
+					name: 'Updated plant',
+					species: 'Dracaena'
+				}
+			}
+		end
+
+		let(:datum) { JSON.parse(response.body, symbolize_names: true) }
+
+		it 'updates a `Plant` in the database' do
+			expect(plant = Plant.find_by(name: 'Updated plant')).to_not be_nil
+
+			expect(plant.name).to eq('Updated plant')
+			expect(plant.species).to eq('Dracaena')
+		end
+
+		it 'returns the plant' do
+			expect(response).to have_http_status(200)
+
+			expect(datum[:name]).to eq('Updated plant')
+			expect(datum[:species]).to eq('Dracaena')
+		end
+	end
+
+	describe 'DELETE#destroy' do
+		before do
+			delete plant_url(plant)
+		end
+
+		let(:plant) { Plant.first }
+
+		it 'deletes the plant from the database' do
+			expect(Plant.find(plant.id)).to be_nil
+		end
+
+		it 'returns a valid response' do
+			expect(response).to have_http_status(204)
+			expect(response.body).to be_empty
 		end
 	end
 end

--- a/spec/requests/plants_spec.rb
+++ b/spec/requests/plants_spec.rb
@@ -1,23 +1,26 @@
 require 'rails_helper'
 
-RSpec.describe "plants requests", type: :request do
-	shared_examples "a valid schema" do
-		context "a list of plants" do
-			it "should be a top-level array with two elements" do
-				expect(data).to be_a(Array)
-				expect(data.count).to eq(2)
-			end
+RSpec.describe 'plants requests', type: :request do
+	shared_examples 'a valid schema' do
+		it 'should be a hash with five elements' do
+			expect(datum).to be_a(Hash)
+			expect(datum.count).to eq(5)
+		end
 
-			it "should have timestamps" do
-				data.each do |datum|
-					expect(datum[:created_at].to_datetime).to_not be_nil
-					expect(datum[:updated_at].to_datetime).to_not be_nil
-				end
-			end
+		it 'should have the expected keys' do
+			expect(datum[:id]).to be_a(Integer)
+			expect(datum[:name]).to_not be_nil
+			expect(datum[:species]).to_not be_nil
+		end
+
+		it 'should have timestamps' do
+			expect(datum[:created_at].to_datetime).to_not be_nil
+			expect(datum[:updated_at].to_datetime).to_not be_nil
 		end
 	end
 
-  describe "GET /index" do
+	# NOTE: These test cases rely upon fixtures for pre-defined model instances
+	describe 'GET /index' do
 		before do
 			get plants_url
 		end
@@ -26,19 +29,45 @@ RSpec.describe "plants requests", type: :request do
 
 		it 'retrieves a list of plants' do
 			expect(response).to have_http_status(200)
+			expect(data).to be_an(Array)
+			expect(data.count).to eq(2)
 
 			first_plant = data.first
-			expect(first_plant[:id]).to be_a(Integer)
+			expect(first_plant[:id]).to be_an(Integer)
 			expect(first_plant[:name]).to eq("Stefan's Plant")
 			expect(first_plant[:species]).to eq('Peace Lily')
 
 			second_plant = data.last
-			expect(second_plant[:id]).to be_a(Integer)
+			expect(second_plant[:id]).to be_an(Integer)
 			expect(second_plant[:name]).to eq('Other Plant')
 			expect(second_plant[:species]).to eq('Parlor Palm')
 		end
 
-		it_behaves_like "a valid schema"
-  end
+		it_behaves_like 'a valid schema' do
+			let(:datum) { data.first }
+		end
+
+		it_behaves_like 'a valid schema' do
+			let(:datum) { data.last }
+		end
+	end
+
+	describe 'GET /:id' do
+		before do
+			plant = Plant.create!(name: 'Spec plant', species: 'Spec species')
+			get plant_url(plant)
+		end
+
+		let(:datum) { JSON.parse(response.body, symbolize_names: true) }
+
+		it_behaves_like 'a valid schema'
+
+		it 'retrieves the plant' do
+			expect(response).to have_http_status(200)
+
+			expect(datum[:name]).to eq('Spec plant')
+			expect(datum[:species]).to eq('Spec species')
+		end
+	end
 end
 

--- a/test/controllers/plants_controller_test.rb
+++ b/test/controllers/plants_controller_test.rb
@@ -83,7 +83,7 @@ class PlantsControllerTest < ActionDispatch::IntegrationTest
 	# Subroutine to check if the hash has expected timestamps
 	# @param data [Hash] The hash to check
 	def assert_has_timestamps(data)
-		assert_not_empty(data[:created_at])
-		assert_not_empty(data[:updated_at])
+		assert_not_empty(data[:created_at].to_datetime)
+		assert_not_empty(data[:updated_at].to_datetime)
 	end
 end

--- a/test/controllers/plants_controller_test.rb
+++ b/test/controllers/plants_controller_test.rb
@@ -1,8 +1,8 @@
-require "test_helper"
+require 'test_helper'
 
-# These test cases use fixtures for pre-defined model instances
+# NOTE: These test cases rely on fixtures for pre-defined model instances
 class PlantsControllerTest < ActionDispatch::IntegrationTest
-	test "should get index" do
+	test 'should get index' do
 		get plants_url
 		assert_response :success
 
@@ -13,17 +13,17 @@ class PlantsControllerTest < ActionDispatch::IntegrationTest
 		first_plant = data.first.symbolize_keys
 		assert(first_plant[:id].is_a?(Integer))
 		assert_equal("Stefan's Plant", first_plant[:name])
-		assert_equal("Peace Lily", first_plant[:species])
+		assert_equal('Peace Lily', first_plant[:species])
 		assert_has_timestamps(first_plant)
 
 		second_plant = data.last.symbolize_keys
 		assert(second_plant[:id].is_a?(Integer))
-		assert_equal("Other Plant", second_plant[:name])
-		assert_equal("Parlor Palm", second_plant[:species])
+		assert_equal('Other Plant', second_plant[:name])
+		assert_equal('Parlor Palm', second_plant[:species])
 		assert_has_timestamps(second_plant)
 	end
 
-	test "should get show" do
+	test 'should get show' do
 		plant = Plant.first!
 		get plant_url(plant)
 		assert_response :success
@@ -34,7 +34,7 @@ class PlantsControllerTest < ActionDispatch::IntegrationTest
 		assert_has_timestamps(data)
 	end
 
-	test "should POST create" do
+	test 'should POST create' do
 		post plants_url, params: {
 			plant: {
 				name: 'New plant',
@@ -49,7 +49,7 @@ class PlantsControllerTest < ActionDispatch::IntegrationTest
 		assert_has_timestamps(data)
 	end
 
-	test "should PUT update" do
+	test 'should PUT update' do
 		plant = Plant.first!
 		put plant_url(plant), params: {
 			plant: {
@@ -70,7 +70,7 @@ class PlantsControllerTest < ActionDispatch::IntegrationTest
 		assert_equal('Dracaena', plant.species)
 	end
 
-	test "should DELETE destroy" do
+	test 'should DELETE destroy' do
 		p = Plant.first!
 		delete plant_url(p)
 		assert_response :no_content
@@ -83,7 +83,7 @@ class PlantsControllerTest < ActionDispatch::IntegrationTest
 	# Subroutine to check if the hash has expected timestamps
 	# @param data [Hash] The hash to check
 	def assert_has_timestamps(data)
-		assert_not_empty(data[:created_at].to_datetime)
-		assert_not_empty(data[:updated_at].to_datetime)
+		assert_not_nil(data[:created_at].to_datetime)
+		assert_not_nil(data[:updated_at].to_datetime)
 	end
 end


### PR DESCRIPTION
Implements [request specs](https://rspec.info/features/6-0/rspec-rails/request-specs/request-spec/) for the plants endpoints.

These are strictly for happy path scenarios and do not test invalid request edges.